### PR TITLE
Refactor code, add support for global values and more padding/margin syntax

### DIFF
--- a/src/functions.scss
+++ b/src/functions.scss
@@ -1,4 +1,12 @@
-// Replace `$substring` with `$value` in `$string`
+/// Replaces `$substring` with `$value` in `$string`
+/// 
+/// @param {string} $string
+///     The string from which you want to replace a value
+/// @param {string} $substring
+///     The substring that you whish to replace
+/// @param {string} $value 
+///     The value which you want to replace the substring with (default '')
+/// @return {string} `$string` where `$substring` is equal to `$value`  
 @function str-replace($string, $substring, $value: '') {
     $index: str-index($string, $substring);
     

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,5 +1,6 @@
 /* TODO: Figure out specificity (User :where() psuedo element? See input[type="file"]) */
 
+
 @use './reset/reset.scss';
 @use './semantic/semantic.scss';
 @use './utility/utility.scss';

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,6 +1,5 @@
 /* TODO: Figure out specificity (User :where() psuedo element? See input[type="file"]) */
 
-
 @use './reset/reset.scss';
 @use './semantic/semantic.scss';
 @use './utility/utility.scss';

--- a/src/utility/display.scss
+++ b/src/utility/display.scss
@@ -1,7 +1,9 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/display
 
 @import '../functions.scss';
+@import '../values.scss';
 
+// TODO: Find out if there are more values here?
 $displayValues: (
   block,
   inline,
@@ -24,14 +26,17 @@ $displayValues: (
   table,
   table-row,
   list-item,
-  inherit,
-  initial,
-  revert,
-  revert-layer,
-  unset
 );
 
 @each $value in $displayValues {
+  $stringValue: inspect($value); // Convert the value to a string
+  $class-name: str-replace($stringValue, ' ', '-');
+  .display-#{$class-name} {
+    display: #{$value};
+  }
+}
+
+@each $value in $global-values {
   $stringValue: inspect($value); // Convert the value to a string
   $class-name: str-replace($stringValue, ' ', '-');
   .display-#{$class-name} {

--- a/src/utility/flex-grow.scss
+++ b/src/utility/flex-grow.scss
@@ -1,9 +1,20 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow
 
+// ACCEPTED VALUES
+// <number>
+
+@import '../values.scss';
+
 $multipliers: 0 25 50 75 100 200 300 400 500;
 
 @each $multiplier in $multipliers {
   .flex-grow-#{$multiplier} {
     flex-grow: calc($multiplier / 100);
+  }
+}
+
+@each $value in $global-values {
+  .flex-grow-#{$value} {
+    flex-grow: #{$value};
   }
 }

--- a/src/utility/font-weight.scss
+++ b/src/utility/font-weight.scss
@@ -1,5 +1,14 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
 
+// ACCEPTED VALUES
+// Normal
+// Bold
+// <number>
+// lighter
+// bolder
+
+@import '../values.scss';
+
 $values: (
   normal,
   bold,
@@ -14,14 +23,15 @@ $values: (
   900,
   lighter,
   bolder,
-  inherit,
-  initial,
-  revert,
-  revert-layer,
-  unset
 );
 
 @each $value in $values {
+  .font-weight-#{$value} {
+    font-weight: #{$value};
+  }
+}
+
+@each $value in $global-values {
   .font-weight-#{$value} {
     font-weight: #{$value};
   }

--- a/src/utility/gap.scss
+++ b/src/utility/gap.scss
@@ -11,3 +11,9 @@
     gap: calc($multiplier / 100) + rem;
   }
 }
+
+@each $value in $global-values {
+  .gap-#{$value} {
+    gap: #{$value};
+  }
+}

--- a/src/utility/gap.scss
+++ b/src/utility/gap.scss
@@ -1,8 +1,12 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/gap
 
-$multipliers: 0 25 50 75 100 200 300 400 500;
+// ACCEPTED VALUES
+// <length>
+// <percentage>
 
-@each $multiplier in $multipliers {
+@import '../values.scss';
+
+@each $multiplier in $root-em-multipliers {
   .gap-#{$multiplier} {
     gap: calc($multiplier / 100) + rem;
   }

--- a/src/utility/margin.scss
+++ b/src/utility/margin.scss
@@ -34,4 +34,3 @@ $class-names: (
     #{$class-name}: auto;
   }
 }
-

--- a/src/utility/margin.scss
+++ b/src/utility/margin.scss
@@ -1,52 +1,37 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/margin
 
-$multipliers: 0 25 50 75 100 200 300 400 500;
+// ACCEPTED VALUES
+// <length>
+// <percentage>
+// auto
 
-// Margin
-@each $multiplier in $multipliers {
-  .margin-#{$multiplier} {
-    margin: calc($multiplier / 100) + rem;
+$class-names: (
+  'margin',
+  'margin-block',
+  'margin-inline',
+  'margin-top',
+  'margin-right',
+  'margin-bottom',
+  'margin-left'
+);
+
+@import '../values.scss';
+
+@each $class-name in $class-names {
+  @each $multiplier in $root-em-multipliers {
+    .#{$class-name}-#{$multiplier} {
+      #{$class-name}: calc($multiplier / 100) + rem;
+    }
+  }
+
+  @each $value in $global-values {
+    .#{$class-name}-#{$value} {
+      #{$class-name}: $value;
+    }
+  }
+
+  .#{$class-name}-auto {
+    #{$class-name}: auto;
   }
 }
 
-// Margin block (Y-axis)
-@each $multiplier in $multipliers {
-  .margin-block-#{$multiplier} {
-    margin-block: calc($multiplier / 100) + rem;
-  }
-}
-
-// Margin inline (X-axis)
-@each $multiplier in $multipliers {
-  .margin-inline-#{$multiplier} {
-    margin-inline: calc($multiplier / 100) + rem;
-  }
-}
-
-// Margin Top
-@each $multiplier in $multipliers {
-  .margin-top-#{$multiplier} {
-    margin-top: calc($multiplier / 100) + rem;
-  }
-}
-
-// Margin Right
-@each $multiplier in $multipliers {
-  .margin-right-#{$multiplier} {
-    margin-right: calc($multiplier / 100) + rem;
-  }
-}
-
-// Margin Bottom
-@each $multiplier in $multipliers {
-  .margin-bottom-#{$multiplier} {
-    margin-bottom: calc($multiplier / 100) + rem;
-  }
-}
-
-// Margin Left
-@each $multiplier in $multipliers {
-  .margin-left-#{$multiplier} {
-    margin-left: calc($multiplier / 100) + rem;
-  }
-}

--- a/src/utility/margin.scss
+++ b/src/utility/margin.scss
@@ -8,7 +8,11 @@
 $class-names: (
   'margin',
   'margin-block',
+  'margin-block-start',
+  'margin-block-end',
   'margin-inline',
+  'margin-inline-start',
+  'margin-inline-end',
   'margin-top',
   'margin-right',
   'margin-bottom',

--- a/src/utility/padding.scss
+++ b/src/utility/padding.scss
@@ -7,7 +7,11 @@
 $class-names: (
   'padding',
   'padding-block',
+  'padding-block-start',
+  'padding-block-end',
   'padding-inline',
+  'padding-inline-start',
+  'padding-inline-end',
   'padding-top',
   'padding-right',
   'padding-bottom',

--- a/src/utility/padding.scss
+++ b/src/utility/padding.scss
@@ -1,52 +1,76 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/padding
 
-$multipliers: 0 25 50 75 100 200 300 400 500;
+@import '../values.scss';
 
 // padding
-@each $multiplier in $multipliers {
+@each $multiplier in $root-em-multipliers {
   .padding-#{$multiplier} {
     padding: calc($multiplier / 100) + rem;
   }
-}
 
-// padding block (Y-axis)
-@each $multiplier in $multipliers {
+  // padding block (Y-axis)
   .padding-block-#{$multiplier} {
     padding-block: calc($multiplier / 100) + rem;
   }
-}
 
-// padding inline X
-@each $multiplier in $multipliers {
+  // padding inline X
   .padding-inline-#{$multiplier} {
     padding-inline: calc($multiplier / 100) + rem;
   }
-}
 
-// padding Top
-@each $multiplier in $multipliers {
+  // padding Top
   .padding-top-#{$multiplier} {
     padding-top: calc($multiplier / 100) + rem;
   }
-}
 
-// padding Right
-@each $multiplier in $multipliers {
+  // padding Right
   .padding-right-#{$multiplier} {
     padding-right: calc($multiplier / 100) + rem;
   }
-}
 
-// padding Bottom
-@each $multiplier in $multipliers {
+  // padding Bottom
   .padding-bottom-#{$multiplier} {
     padding-bottom: calc($multiplier / 100) + rem;
   }
-}
 
-// padding Left
-@each $multiplier in $multipliers {
+  // padding Left
   .padding-left-#{$multiplier} {
     padding-left: calc($multiplier / 100) + rem;
+  }
+}
+
+@each $value in $global-values {
+  .padding-#{$value} {
+    padding: $value;
+  }
+
+  // padding block (Y-axis)
+  .padding-block-#{$value} {
+    padding-block: $value;
+  }
+
+  // padding inline X
+  .padding-inline-#{$value} {
+    padding-inline: $value;
+  }
+
+  // padding Top
+  .padding-top-#{$value} {
+    padding-top: $value;
+  }
+
+  // padding Right
+  .padding-right-#{$value} {
+    padding-right: $value;
+  }
+
+  // padding Bottom
+  .padding-bottom-#{$value} {
+    padding-bottom: $value;
+  }
+
+  // padding Left
+  .padding-left-#{$value} {
+    padding-left: $value;
   }
 }

--- a/src/utility/padding.scss
+++ b/src/utility/padding.scss
@@ -1,76 +1,31 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/padding
 
+// ACCEPTED VALUES
+// <length>
+// <percentage>
+
+$class-names: (
+  'padding',
+  'padding-block',
+  'padding-inline',
+  'padding-top',
+  'padding-right',
+  'padding-bottom',
+  'padding-left'
+);
+
 @import '../values.scss';
 
-// padding
-@each $multiplier in $root-em-multipliers {
-  .padding-#{$multiplier} {
-    padding: calc($multiplier / 100) + rem;
+@each $class-name in $class-names {
+  @each $multiplier in $root-em-multipliers {
+    .#{$class-name}-#{$multiplier} {
+      #{$class-name}: calc($multiplier / 100) + rem;
+    }
   }
 
-  // padding block (Y-axis)
-  .padding-block-#{$multiplier} {
-    padding-block: calc($multiplier / 100) + rem;
-  }
-
-  // padding inline X
-  .padding-inline-#{$multiplier} {
-    padding-inline: calc($multiplier / 100) + rem;
-  }
-
-  // padding Top
-  .padding-top-#{$multiplier} {
-    padding-top: calc($multiplier / 100) + rem;
-  }
-
-  // padding Right
-  .padding-right-#{$multiplier} {
-    padding-right: calc($multiplier / 100) + rem;
-  }
-
-  // padding Bottom
-  .padding-bottom-#{$multiplier} {
-    padding-bottom: calc($multiplier / 100) + rem;
-  }
-
-  // padding Left
-  .padding-left-#{$multiplier} {
-    padding-left: calc($multiplier / 100) + rem;
-  }
-}
-
-@each $value in $global-values {
-  .padding-#{$value} {
-    padding: $value;
-  }
-
-  // padding block (Y-axis)
-  .padding-block-#{$value} {
-    padding-block: $value;
-  }
-
-  // padding inline X
-  .padding-inline-#{$value} {
-    padding-inline: $value;
-  }
-
-  // padding Top
-  .padding-top-#{$value} {
-    padding-top: $value;
-  }
-
-  // padding Right
-  .padding-right-#{$value} {
-    padding-right: $value;
-  }
-
-  // padding Bottom
-  .padding-bottom-#{$value} {
-    padding-bottom: $value;
-  }
-
-  // padding Left
-  .padding-left-#{$value} {
-    padding-left: $value;
+  @each $value in $global-values {
+    .#{$class-name}-#{$value} {
+      #{$class-name}: $value;
+    }
   }
 }

--- a/src/values.scss
+++ b/src/values.scss
@@ -1,2 +1,4 @@
 $global-values: inherit, initial, revert, revert-layer, unset;
-$root-em-multipliers: 0, 25, 50, 75, 100, 200, 300, 400, 500;
+$root-em-multipliers: 0, 25, 50, 75, 100, 200, 300, 400, 500; 
+// TODO: See if theese should use .25rem, .5rem...
+// TODO: Figure out how to use percentages

--- a/src/values.scss
+++ b/src/values.scss
@@ -1,0 +1,2 @@
+$global-values: inherit, initial, revert, revert-layer, unset;
+$root-em-multipliers: 0, 25, 50, 75, 100, 200, 300, 400, 500;


### PR DESCRIPTION
- Refactor code
Make greater use of SASS syntax to reduce the overall amount of code. Add comments clarifying the accepted values of each class

- Add support for global values 
All classes now support global values (inherit, initial, revert, revert-layer, unset)

- Added syntax for padding and margin
Both padding and margin now support usage of  block-start/end aswell as inline-start/end syntax. Margins now also support the usage of the auto value.